### PR TITLE
pam_sm_setcred

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following instructions have been tested and validated to work on an Ubuntu (
 ### Package dependencies
 
 ```
-apt install libpam-dev libcurl4-gnutls-dev libssl-dev check build-essential
+apt install libpam-dev libpam-cap libcurl4-gnutls-dev libssl-dev check build-essential cmake pkg-config
 ```
 
 ### Generating keys

--- a/src/pam_visa.c
+++ b/src/pam_visa.c
@@ -49,3 +49,8 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc, const char **a
 
     return PAM_IGNORE;
 }
+
+PAM_EXTERN
+int pam_sm_setcred(pam_handle_t * pamh, int flags, int argc, const char **argv) {
+    return PAM_SUCCESS;
+}


### PR DESCRIPTION
This fixes the following message about the `pam_sm_setcred` function, observed in the `/var/log/auth.log` log file on Ubuntu Jammy 22.04:
```
... xrdp-sesman[768]: PAM unable to resolve symbol: pam_sm_setcred
```

These changes are not (theoretically) supposed to affect the functionality of the PAM module as, according to [the pam_sm_setcred(3) documentation](https://linux.die.net/man/3/pam_sm_setcred), the sole purpose of this function is to make information about the user available to the application. 